### PR TITLE
Handle missing data in training script

### DIFF
--- a/ml/run_train.py
+++ b/ml/run_train.py
@@ -60,7 +60,11 @@ def main():
         downsample_secs=(args.downsample_secs or None),
     )
     if df_feat.is_empty():
-        raise RuntimeError("No features after streaming build")
+        print(
+            "No data found for the specified sport and date range; "
+            "skipping training."
+        )
+        return
 
     print(f"Feature rows: {df_feat.height:,} (from ~{total_raw:,} raw snapshot rows scanned)")
     print("Training model...")


### PR DESCRIPTION
## Summary
- Avoid runtime error when no data found for training

## Testing
- ⚠️ `python -m ml.run_train --curated s3://betfair-curated --sport horse-racing --date 2025-09-12 --days 1 --preoff-mins 30 --batch-markets 100 --downsample-secs 0` *(missing dependency: polars)*
- ✅ `python -m py_compile ml/run_train.py`


------
https://chatgpt.com/codex/tasks/task_e_68c52f130b90833398eaea779b490a74