### PR TITLE
Handle missing win labels in feature builder

### DIFF
--- a/ml/dataio.py
+++ b/ml/dataio.py
@@ -170,7 +170,8 @@ def read_table(path_or_paths, filesystem: pafs.FileSystem | None = None) -> pa.T
     for p in paths:
         # If user passes a file path directly, accept it; else expand dir
         if p.lower().endswith(".parquet"):
-            file_list.append(_to_fs_path(fileystem, p))  # type: ignore[name-defined]
+            # direct file path supplied
+            file_list.append(_to_fs_path(filesystem, p))
         else:
             file_list.extend(_list_parquet_files(filesystem, p))
 


### PR DESCRIPTION
## Summary
- Derive `winLabel` from `runnerStatus` when missing so streaming feature build produces data
- Fix typo in `dataio.read_table` when handling direct parquet file paths

## Testing
- `python -m py_compile ml/features.py ml/dataio.py`
- `python -m ml.run_train --curated s3://betfair-curated --sport horse-racing --date 2025-09-12 --days 1 --preoff-mins 30 --batch-markets 100 --downsample-secs 0` *(fails: ModuleNotFoundError: No module named 'polars')*

------
https://chatgpt.com/codex/tasks/task_e_68c67bf68890833396bf53b87fc87773