### PR TITLE
Only list dates containing parquet files

### DIFF
--- a/ml/dataio.py
+++ b/ml/dataio.py
@@ -235,7 +235,10 @@ def list_dates(curated_root: str, sport: str, dataset: str) -> List[str]:
         # guard: FileInfo may return full path including bucket/key or absolute path
         name = os.path.basename(info.path)
         if name.startswith("date="):
-            out.append(name.split("=", 1)[1])
+            # only include dates that have at least one parquet file
+            full_path = info.path
+            if _list_parquet_files(fs, full_path):
+                out.append(name.split("=", 1)[1])
     return sorted(out)
 
 


### PR DESCRIPTION
## Summary
- Only include dates that contain at least one parquet file in `list_dates`
- Preserve sorted output for callers such as `ml/run_train.py`

## Testing
- `python -m py_compile ml/dataio.py ml/run_train.py`
- Attempted to run `python - <<'PY'\nfrom ml import dataio\nprint(dataio.list_dates('/tmp/testdataset', 'horse', 'orderbook_snapshots_5s'))\nPY` *(failed: ModuleNotFoundError: No module named 'pyarrow')*
- Attempted to run `pip install pyarrow` *(failed: Could not find a version that satisfies the requirement pyarrow)*

------
https://chatgpt.com/codex/tasks/task_e_68c67fea6e248333a1e7a94b072d661c