### PR TITLE
fix: ensure partition paths end with slash

### DIFF
--- a/ml/dataio.py
+++ b/ml/dataio.py
@@ -131,7 +131,7 @@ def _has_any(fs: pafs.FileSystem, path: str) -> bool:
 
 def _p(curated_root: str, dataset: str, sport: str, date: str) -> str:
     # <root>/<dataset>/sport=<sport>/date=<YYYY-MM-DD>
-    return f"{curated_root.rstrip('/')}/{dataset}/sport={sport}/date={date}"
+    return f"{curated_root.rstrip('/')}/{dataset}/sport={sport}/date={date}/"
 
 def ds_orderbook(curated_root: str, sport: str, date: str) -> str:
     return _p(curated_root, "orderbook_snapshots_5s", sport, date)


### PR DESCRIPTION
## Summary
- include trailing slash when building partitioned dataset paths to satisfy PyArrow on S3

## Testing
- `python -m py_compile ml/dataio.py ml/features.py`
- `python -m ml.run_train --help` *(fails: ModuleNotFoundError: No module named 'polars')*
- `pip install polars` *(fails: Could not find a version that satisfies the requirement polars)*

------
https://chatgpt.com/codex/tasks/task_e_68c68218fbe08333a4d6d7ba155f415f