### PR TITLE
Filter empty snapshot directories before dataset creation

### DIFF
--- a/ml/features.py
+++ b/ml/features.py
@@ -110,8 +110,11 @@ def build_features_streaming(
     df_res = pl.from_arrow(dataio.read_table(res_paths, filesystem=fs))
 
     # Arrow dataset for snapshots (stable for MinIO/S3)
-    snap_dirs = [dataio.ds_orderbook(root, sport, d) for d in dates]
-    snap_dirs = [dataio._to_fs_path(fs, p) for p in snap_dirs]
+    snap_dirs = []
+    for d in dates:
+        p = dataio.ds_orderbook(root, sport, d)
+        if dataio._list_parquet_files(fs, p):
+            snap_dirs.append(dataio._to_fs_path(fs, p).rstrip("/"))
     if not snap_dirs:
         logging.warning(
             "No orderbook snapshot directories for sport=%s and dates %s", sport, dates


### PR DESCRIPTION
## Summary
- Only include snapshot directories that actually contain parquet files when building the Arrow dataset
- Avoid trailing slashes so dataset reads the directory correctly

## Testing
- `python -m ml.run_train --help` *(fails: No module named 'polars')*
- `pip install polars --quiet` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m ml.dataio . horse-racing orderbook_snapshots_5s` *(fails: No module named 'pyarrow')*
- `pip install pyarrow --quiet` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c6853b6ab48333bd7d46b0953387c3